### PR TITLE
Remove CSS restricting resize of textarea

### DIFF
--- a/assets/opstools/ProcessTranslation/ProcessTranslation.css
+++ b/assets/opstools/ProcessTranslation/ProcessTranslation.css
@@ -51,10 +51,6 @@ li.active {
 }
 
 /*Form*/
-textarea.tr-field-data {
-   resize: none;
-}
-
 .tr-translate-body .col-xs-6 {
 	margin-top: 10px;
 }


### PR DESCRIPTION
LuukWha is having trouble translating some descriptions that are longer than the provided space...this will allow her to control what she sees on the event the description spill over.